### PR TITLE
download snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 data/*
 !data/README.md
-!data/mongo
 build/catapult-config/*
 !build/catapult-config/README.md
 build/generated-addresses/*
@@ -10,3 +9,4 @@ build/nemesis/*
 build/state/*
 !build/state/README.md
 testnet/data/api-node-0
+testnet/data/mongo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/*
 !data/README.md
+!data/mongo
 build/catapult-config/*
 !build/catapult-config/README.md
 build/generated-addresses/*

--- a/data/mongo
+++ b/data/mongo
@@ -1,0 +1,1 @@
+../testnet/data/mongo/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,21 +42,12 @@ services:
 
   db:
     image: mongo
-    command: bash -c "mongod --dbpath=/dbdata --bind_ip=db"
+    command: bash -c "/bin-mount/wait /state/configs-edited && mongod --dbpath=/dbdata --bind_ip=db"
     stop_signal: SIGINT
     volumes:
     - ./data/mongo:/dbdata:rw
     - ./bin/bash:/bin-mount
-
-  init-db:
-    image: mongo
-    command:  bash -c "/bin/bash /userconfig/mongors.sh"
-    volumes:
-    - ./data/mongo:/dbdata:rw
-    - ./static-config/mongo/:/userconfig/:ro
-    - ./bin/bash:/bin-mount
-    depends_on:
-    - db
+    - ./build/state:/state
 
   rest-gateway:
     image: techbureau/catapult-rest-server:1.0.14
@@ -68,7 +59,6 @@ services:
     - ./bin/ash:/bin-mount
     - ./build/state:/state
     depends_on:
-    - init-db
     - generate-configs
 
   peer-node-1:

--- a/dockerfiles/testnet/Dockerfile
+++ b/dockerfiles/testnet/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:16.04
 
-RUN apt install sed grep coreutils git-core
+RUN apt-get -y update && apt-get -y install sed grep coreutils wget

--- a/testnet/generate-configurations.sh
+++ b/testnet/generate-configurations.sh
@@ -128,10 +128,11 @@ config_rest_gateway
 # save configuration in git
 save_state_with_git
 
-# save config state
-touch ${STATE_PATH}/configs-edited
-
 # download snapshot
 download_snapshot
 
+# save config state
+touch ${STATE_PATH}/configs-edited
+
 echo Done configuring your Catapult Testnet node!
+

--- a/testnet/generate-configurations.sh
+++ b/testnet/generate-configurations.sh
@@ -13,6 +13,7 @@ TAIL_BIN=`which tail`
 SED_BIN=`which sed`
 AWK_BIN=`which awk`
 GIT_BIN=`which git`
+WGET_BIN=`which wget`
 
 # verify current state
 if [ -e ${STATE_PATH}/configs-edited ];
@@ -95,6 +96,11 @@ save_state_with_git() {
     ${GIT_BIN} commit -m "testnet configuration done"
 }
 
+download_snapshot() {
+    ${WGET_BIN} -O /tmp/api-node-data-190514.tar.gz  http://jp5.nemesis.land/share/api-node-data-190514.tar.gz
+    tar xfzv /tmp/api-node-data-190514.tar.gz -C /testnet --overwrite
+}
+
 # temporary config state
 touch ${STATE_PATH}/configs-generated
 
@@ -124,5 +130,8 @@ save_state_with_git
 
 # save config state
 touch ${STATE_PATH}/configs-edited
+
+# download snapshot
+download_snapshot
 
 echo Done configuring your Catapult Testnet node!

--- a/testnet/generate-configurations.sh
+++ b/testnet/generate-configurations.sh
@@ -99,6 +99,7 @@ save_state_with_git() {
 download_snapshot() {
     ${WGET_BIN} -O /tmp/api-node-data-190514.tar.gz  http://jp5.nemesis.land/share/api-node-data-190514.tar.gz
     tar xfzv /tmp/api-node-data-190514.tar.gz -C /testnet --overwrite
+    rm -f /tmp/api-node-data-190514.tar.gz
 }
 
 # temporary config state


### PR DESCRIPTION
in generate-configs service, it download snapshot of mongo and api-node-0
so, init-db is deleted, mongoDB waits for download.
snapshot donwload url is hardcoded.

peer-node-1 is not supported.